### PR TITLE
Modify create survey resolver to return style phrase

### DIFF
--- a/code/api/src/modules/survey/resolvers.js
+++ b/code/api/src/modules/survey/resolvers.js
@@ -3,7 +3,12 @@ import models from '../../setup/models'
 
 //helpers
 const calculateStyle = styleAnswers => {
-  let styles = { 'sporty': 0, 'formal': 0, 'edgy': 0 };
+  const results = {
+    'sporty':'Your style is adventurous and sporty',
+    'preppy': 'Your style is refined and chic',
+    'edgy': 'Your style is fresh and edgy'
+  };
+  let styles = { 'sporty': 0, 'preppy': 0, 'edgy': 0 };
   let greatestCount = 0
   let greatestOccurence = null;
 
@@ -15,8 +20,8 @@ const calculateStyle = styleAnswers => {
       greatestOccurence = answer
     }
   }
-
-  return greatestOccurence
+  
+  return results[greatestOccurence]
 };
 
 // Create a survey without auth


### PR DESCRIPTION
#### What's this PR do?

Modified create survey resolver to save and return a full phrase for style, instead of a one word return.

#### Where should the reviewer start?

api/src/modules/survey/resolvers.js, the helper function called 'calculateStyle'

#### How should this be manually tested?

Graphiql


#### Any background context you want to provide?

N/A


#### Screenshots (if appropriate)

<img width="415" alt="Screen Shot 2020-07-11 at 3 35 06 PM" src="https://user-images.githubusercontent.com/50722111/87234217-231a8600-c38c-11ea-85d2-e78f4568f8c5.png">


#### Questions:

N/A
